### PR TITLE
fix: 🐛 adjusting signature position in sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -667,6 +667,11 @@ const Sidebar = (theme: Theme) => `
     justify-content: center;
     text-shadow: 1px 1px 7px rgb(255 255 255 / 50%);
   }
+  
+  .feedbot-signature a {
+    height: unset;
+    display: flex;
+  }
 
   .feedbot-signature a img {
     height: 22px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -662,8 +662,9 @@ const Sidebar = (theme: Theme) => `
   }
 
   .feedbot-wrapper .feedbot-signature {
-    bottom: 1px;
+    bottom: 0px;
     left: 0px;
+    height: 24px;
     justify-content: center;
     text-shadow: 1px 1px 7px rgb(255 255 255 / 50%);
   }


### PR DESCRIPTION
Fixed weird positioning of the feedyou signature in the sidebar.