### PR TITLE
feature/fincentrum disabling screenshot in safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ directLine: {
   webSocket?: boolean = true
 },
 theme?: {
-  mainColor?: string
+  mainColor?: string,
+  enableScreenshotUpload?: boolean
 },
 header?: {
   text?: string,

--- a/samples/feedyou/sidebar.html
+++ b/samples/feedyou/sidebar.html
@@ -1,42 +1,41 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Chatbot</title>
-  </head>
-  <body style="margin: 0; padding: 0">
-    <!-- PUT THIS CODE RIGHT BEFORE THE </BODY> TAG (you can also use some tag manager like GTM) AND REPLACE ... WITH BOT ID -->
-    <!--  • design and behavior of webchat could be configured remotely from Feedyou Designer -->
-    <!--  • all domains where code will be used need to be allowed by Feedyou -->
-    <!--  • it is needed to append #feedbot-test-mode to the URL to show chatbot window during development -->
-    <link
-      href="../../botchat.css"
-      rel="stylesheet"
-    />
-    <div
-      style="
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chatbot</title>
+</head>
+
+<body style="margin: 0; padding: 0">
+  <!-- PUT THIS CODE RIGHT BEFORE THE </BODY> TAG (you can also use some tag manager like GTM) AND REPLACE ... WITH BOT ID -->
+  <!--  • design and behavior of webchat could be configured remotely from Feedyou Designer -->
+  <!--  • all domains where code will be used need to be allowed by Feedyou -->
+  <!--  • it is needed to append #feedbot-test-mode to the URL to show chatbot window during development -->
+  <link href="../../botchat.css" rel="stylesheet" />
+  <div style="
         height: 100vh;
         background: linear-gradient(45deg, #f6ae2d, #33658a);
         background-size: cover;
         background-position: center center;
-      "
-    ></div>
-    <script type="text/javascript">
-      (function (f, y, b, o, t, s) { 
-        (t = y.createElement(b)), (s = y.getElementsByTagName(b)[0]);
-        t.async = 1;
-        t.src = "../../botchat-es5.js";
-        t.onload = function () {
-          BotChat.App({
-            bot: { id: "feedbot-demo-webchat" },
-            theme: { template: { type: "sidebar" }},
-            disableInputWhenNotNeeded: true
-          });
-        };
-        s.parentNode.insertBefore(t, s);
-      })(window, document, "script");
-    </script>
-    <!-- --------------------------------------------------------------------------------------- -->
-  </body>
+      "></div>
+  <script type="text/javascript">
+    (function (f, y, b, o, t, s) {
+      (t = y.createElement(b)), (s = y.getElementsByTagName(b)[0]);
+      t.async = 1;
+      t.src = "../../botchat-es5.js";
+      t.onload = function () {
+        BotChat.App({
+          bot: { id: "feedbot-fincentrum-ifin-test" },
+          directLine: { secret: "6J6VbAtXC1M.btx8TcwVg4ukdPdfYBxVqqMBBeEqaXx5o_DAbGPDRKQ" },
+          theme: { template: { type: "sidebar" } },
+          disableInputWhenNotNeeded: true
+        });
+      };
+      s.parentNode.insertBefore(t, s);
+    })(window, document, "script");
+  </script>
+  <!-- --------------------------------------------------------------------------------------- -->
+</body>
+
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,8 @@ export type Theme = {
   mainColor: string;
   template: any;
   customCss?: string;
-  showSignature?: boolean
+  showSignature?: boolean,
+  enableScreenshotUpload?: boolean
 };
 
 export type AppProps = ChatProps & {
@@ -97,6 +98,8 @@ export const App = async (props: AppProps, container?: HTMLElement) => {
         }
 
         props.theme.showSignature = !config.hideSignature
+
+        props.theme.enableScreenshotUpload = !!config.enableScreenshotUpload
 
         if (config.showInput === "auto") {
           props.disableInputWhenNotNeeded = true;
@@ -499,8 +502,13 @@ const ExpandableKnobTheme = (theme: Theme) => `
     height: 565px;
   }
 
-  ${window.location.hash === '#feedbot-feature-screenshot' && !isSafari() ? `
+  .wc-upload-screenshot {
+    display: none !important;
+  }
+
+  ${theme.enableScreenshotUpload && !isSafari() ? `
     .wc-upload-screenshot {
+      display: inline-block !important;
       position: absolute !important;
       left: 46px !important;
       height: 40px !important;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export type Theme = {
 export type AppProps = ChatProps & {
   theme?: Theme;
   header?: { textWhenCollapsed?: string; text: string };
-  channel?: {index?: number, id?: string},
+  channel?: { index?: number, id?: string },
   autoExpandTimeout?: number;
 };
 
@@ -67,7 +67,7 @@ export const App = async (props: AppProps, container?: HTMLElement) => {
         token: body.token,
       });
       delete props.directLine;
-      
+
       // TODO configurable template system based on config
       const config = body.config;
       const alwaysVisible = config && config.visibility === 'always'
@@ -209,7 +209,7 @@ function getStyleForTheme(theme: Theme, remoteConfig: boolean): string {
   return remoteConfig ? ExpandableKnobTheme(theme) : ExpandableBarTheme(theme);
 }
 
-function getSidebarBackgroundColor (theme: Theme) {
+function getSidebarBackgroundColor(theme: Theme) {
   return '#FFFFFF'
 
   // TODO make background tint configurable in theme
@@ -218,6 +218,10 @@ function getSidebarBackgroundColor (theme: Theme) {
     return rgb2hex(color).hex
   }
   return color*/
+}
+
+export function isSafari() {
+  return !(navigator.userAgent.indexOf("Safari") !== -1 && navigator.userAgent.indexOf("Chrome") !== -1);
 }
 
 const FullScreenTheme = (theme: Theme) => `
@@ -477,11 +481,10 @@ const ExpandableKnobTheme = (theme: Theme) => `
     height: 100%;
     padding: 0px;
 
-    background-image: url(${
-      (theme.template && theme.template.iconUrl)
-        ? theme.template.iconUrl
-        :"https://cdn.feedyou.ai/webchat/message-icon.png"
-    });
+    background-image: url(${(theme.template && theme.template.iconUrl)
+    ? theme.template.iconUrl
+    : "https://cdn.feedyou.ai/webchat/message-icon.png"
+  });
     background-size: 50px 50px;
     background-position: 12px 12px;
     background-repeat: no-repeat;
@@ -496,7 +499,7 @@ const ExpandableKnobTheme = (theme: Theme) => `
     height: 565px;
   }
 
-  ${window.location.hash === '#feedbot-feature-screenshot' ? `
+  ${window.location.hash === '#feedbot-feature-screenshot' && !isSafari() ? `
     .wc-upload-screenshot {
       position: absolute !important;
       left: 46px !important;

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -6,6 +6,7 @@ import { Dispatch, connect } from 'react-redux';
 import { Strings } from './Strings';
 import { Speech } from './SpeechModule'
 import { ChatActions, ListeningState, sendMessage, sendFiles, sendScreenshot } from './Store';
+import { isSafari } from "./App"
 
 import * as html2canvas from 'html2canvas'
 
@@ -78,7 +79,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
         this.textInput.focus();
     }
 
-    private onTextInputFocus(){
+    private onTextInputFocus() {
         if (this.props.listeningState === ListeningState.STARTED) {
             this.props.stopListening();
         }
@@ -101,9 +102,9 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
     }
 
     private async takeScreenshot() {
-        const screen = await html2canvas(document.body, {allowTaint: true, useCORS: true}).then((canvas) => {
+        const screen = await html2canvas(document.body, { allowTaint: true, useCORS: true }).then((canvas) => {
             const dataURI = canvas.toDataURL("image/png");
-            
+
             return dataURI
         })
         this.props.sendScreenshot(screen);
@@ -117,7 +118,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
             this.props.disableInput && 'disable-input'
         );
 
-        const showMicButton = this.props.listeningState !== ListeningState.STOPPED || (Speech.SpeechRecognizer.speechIsAvailable()  && !this.props.inputText.length);
+        const showMicButton = this.props.listeningState !== ListeningState.STOPPED || (Speech.SpeechRecognizer.speechIsAvailable() && !this.props.inputText.length);
 
         const sendButtonClassName = classList(
             'wc-send',
@@ -134,59 +135,59 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
         const placeholder = this.props.listeningState === ListeningState.STARTED ? this.props.strings.listeningIndicator : this.props.strings.consolePlaceholder;
 
         return (
-            <div className={ className }>
+            <div className={className}>
                 {
                     this.props.showUploadButton &&
-                        <label
-                            className="wc-upload"
-                            htmlFor="wc-upload-input"
-                            onKeyPress={ evt => this.handleUploadButtonKeyPress(evt) }
-                            tabIndex={ 0 }
-                        >
-                            <svg>
-                                <path d="M19.96 4.79m-2 0a2 2 0 0 1 4 0 2 2 0 0 1-4 0zM8.32 4.19L2.5 15.53 22.45 15.53 17.46 8.56 14.42 11.18 8.32 4.19ZM1.04 1L1.04 17 24.96 17 24.96 1 1.04 1ZM1.03 0L24.96 0C25.54 0 26 0.45 26 0.99L26 17.01C26 17.55 25.53 18 24.96 18L1.03 18C0.46 18 0 17.55 0 17.01L0 0.99C0 0.45 0.47 0 1.03 0Z" />
-                            </svg>
-                        </label>
+                    <label
+                        className="wc-upload"
+                        htmlFor="wc-upload-input"
+                        onKeyPress={evt => this.handleUploadButtonKeyPress(evt)}
+                        tabIndex={0}
+                    >
+                        <svg>
+                            <path d="M19.96 4.79m-2 0a2 2 0 0 1 4 0 2 2 0 0 1-4 0zM8.32 4.19L2.5 15.53 22.45 15.53 17.46 8.56 14.42 11.18 8.32 4.19ZM1.04 1L1.04 17 24.96 17 24.96 1 1.04 1ZM1.03 0L24.96 0C25.54 0 26 0.45 26 0.99L26 17.01C26 17.55 25.53 18 24.96 18L1.03 18C0.46 18 0 17.55 0 17.01L0 0.99C0 0.45 0.47 0 1.03 0Z" />
+                        </svg>
+                    </label>
                 }
                 {
                     this.props.showUploadButton &&
-                        <input
-                            id="wc-upload-input"
-                            tabIndex={ -1 }
-                            type="file"
-                            ref={ input => this.fileInput = input }
-                            // multiple
-                            onChange={ () => this.onChangeFile() }
-                            aria-label={ this.props.strings.uploadFile }
-                            role="button"
-                        />
+                    <input
+                        id="wc-upload-input"
+                        tabIndex={-1}
+                        type="file"
+                        ref={input => this.fileInput = input}
+                        // multiple
+                        onChange={() => this.onChangeFile()}
+                        aria-label={this.props.strings.uploadFile}
+                        role="button"
+                    />
                 }
                 {
-                    this.props.showUploadButton && window.location.hash === '#feedbot-feature-screenshot' &&
-                    <button className="wc-upload-screenshot" onClick={() => {this.takeScreenshot()}}><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="camera" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="#8a8a8a" d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"></path></svg></button>
+                    this.props.showUploadButton && window.location.hash === '#feedbot-feature-screenshot' && !isSafari() &&
+                    <button className="wc-upload-screenshot" onClick={() => { this.takeScreenshot() }}><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="camera" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="#8a8a8a" d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"></path></svg></button>
                 }
                 <div className="wc-textbox">
                     <textarea
                         className="wc-shellinput"
-                        ref={ input => this.textInput = input }
+                        ref={input => this.textInput = input}
                         autoFocus
-                        value={ this.props.inputText }
-                        onChange={ _ => this.props.onChangeText(this.textInput.value) }
-                        onKeyPress={ e => this.onKeyPress(e) }
-                        onFocus={ () => this.onTextInputFocus() }
-                        placeholder={ placeholder }
-                        disabled={ this.props.disableInput }
-                        aria-label={ this.props.inputText ? null : placeholder }
+                        value={this.props.inputText}
+                        onChange={_ => this.props.onChangeText(this.textInput.value)}
+                        onKeyPress={e => this.onKeyPress(e)}
+                        onFocus={() => this.onTextInputFocus()}
+                        placeholder={placeholder}
+                        disabled={this.props.disableInput}
+                        aria-label={this.props.inputText ? null : placeholder}
                         aria-live="polite"
                     ></textarea>
                 </div>
                 <button
-                    className={ sendButtonClassName }
-                    onClick={ () => this.onClickSend() }
-                    aria-label={ this.props.strings.send }
+                    className={sendButtonClassName}
+                    onClick={() => this.onClickSend()}
+                    aria-label={this.props.strings.send}
                     role="button"
-                    onKeyPress={ evt => this.handleSendButtonKeyPress(evt) }
-                    tabIndex={ 0 }
+                    onKeyPress={evt => this.handleSendButtonKeyPress(evt)}
+                    tabIndex={0}
                     type="button"
                 >
                     <svg>
@@ -194,17 +195,17 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                     </svg>
                 </button>
                 <button
-                    className={ micButtonClassName }
-                    onClick={ () => this.onClickMic() }
-                    aria-label={ this.props.strings.speak }
+                    className={micButtonClassName}
+                    onClick={() => this.onClickMic()}
+                    aria-label={this.props.strings.speak}
                     role="button"
-                    tabIndex={ 0 }
+                    tabIndex={0}
                     type="button"
                 >
-                   <svg width="28" height="22" viewBox="0 0 58 58" >
-                        <path d="M 44 28 C 43.448 28 43 28.447 43 29 L 43 35 C 43 42.72 36.72 49 29 49 C 21.28 49 15 42.72 15 35 L 15 29 C 15 28.447 14.552 28 14 28 C 13.448 28 13 28.447 13 29 L 13 35 C 13 43.485 19.644 50.429 28 50.949 L 28 56 L 23 56 C 22.448 56 22 56.447 22 57 C 22 57.553 22.448 58 23 58 L 35 58 C 35.552 58 36 57.553 36 57 C 36 56.447 35.552 56 35 56 L 30 56 L 30 50.949 C 38.356 50.429 45 43.484 45 35 L 45 29 C 45 28.447 44.552 28 44 28 Z"/>
-                        <path id="micFilling" d="M 28.97 44.438 L 28.97 44.438 C 23.773 44.438 19.521 40.033 19.521 34.649 L 19.521 11.156 C 19.521 5.772 23.773 1.368 28.97 1.368 L 28.97 1.368 C 34.166 1.368 38.418 5.772 38.418 11.156 L 38.418 34.649 C 38.418 40.033 34.166 44.438 28.97 44.438 Z"/>
-                        <path d="M 29 46 C 35.065 46 40 41.065 40 35 L 40 11 C 40 4.935 35.065 0 29 0 C 22.935 0 18 4.935 18 11 L 18 35 C 18 41.065 22.935 46 29 46 Z M 20 11 C 20 6.037 24.038 2 29 2 C 33.962 2 38 6.037 38 11 L 38 35 C 38 39.963 33.962 44 29 44 C 24.038 44 20 39.963 20 35 L 20 11 Z"/>
+                    <svg width="28" height="22" viewBox="0 0 58 58" >
+                        <path d="M 44 28 C 43.448 28 43 28.447 43 29 L 43 35 C 43 42.72 36.72 49 29 49 C 21.28 49 15 42.72 15 35 L 15 29 C 15 28.447 14.552 28 14 28 C 13.448 28 13 28.447 13 29 L 13 35 C 13 43.485 19.644 50.429 28 50.949 L 28 56 L 23 56 C 22.448 56 22 56.447 22 57 C 22 57.553 22.448 58 23 58 L 35 58 C 35.552 58 36 57.553 36 57 C 36 56.447 35.552 56 35 56 L 30 56 L 30 50.949 C 38.356 50.429 45 43.484 45 35 L 45 29 C 45 28.447 44.552 28 44 28 Z" />
+                        <path id="micFilling" d="M 28.97 44.438 L 28.97 44.438 C 23.773 44.438 19.521 40.033 19.521 34.649 L 19.521 11.156 C 19.521 5.772 23.773 1.368 28.97 1.368 L 28.97 1.368 C 34.166 1.368 38.418 5.772 38.418 11.156 L 38.418 34.649 C 38.418 40.033 34.166 44.438 28.97 44.438 Z" />
+                        <path d="M 29 46 C 35.065 46 40 41.065 40 35 L 40 11 C 40 4.935 35.065 0 29 0 C 22.935 0 18 4.935 18 11 L 18 35 C 18 41.065 22.935 46 29 46 Z M 20 11 C 20 6.037 24.038 2 29 2 C 33.962 2 38 6.037 38 11 L 38 35 C 38 39.963 33.962 44 29 44 C 24.038 44 20 39.963 20 35 L 20 11 Z" />
                     </svg>
                 </button>
             </div>
@@ -224,30 +225,30 @@ export const Shell = connect(
         user: state.connection.user,
         listeningState: state.shell.listeningState
     }), {
-        // passed down to ShellContainer
-        onChangeText: (input: string) => ({ type: 'Update_Input', input, source: "text" } as ChatActions),
-        stopListening:  () => ({ type: 'Listening_Stopping' }),
-        startListening:  () => ({ type: 'Listening_Starting' }),
-        // only used to create helper functions below
-        sendMessage,
-        sendFiles,
-        sendScreenshot
-    }, (stateProps: any, dispatchProps: any, ownProps: any): Props => ({
-        // from stateProps
-        inputText: stateProps.inputText,
-        showUploadButton: stateProps.showUploadButton,
-        disableInput: stateProps.disableInput,
-        strings: stateProps.strings,
-        listeningState: stateProps.listeningState,
-        // from dispatchProps
-        onChangeText: dispatchProps.onChangeText,
-        // helper functions
-        sendMessage: (text: string) => dispatchProps.sendMessage(text, stateProps.user, stateProps.locale),
-        sendFiles: (files: FileList) => dispatchProps.sendFiles(files, stateProps.user, stateProps.locale),
-        sendScreenshot: (screen: string) => dispatchProps.sendScreenshot(screen, stateProps.user, stateProps.locale),
-        startListening: () => dispatchProps.startListening(),
-        stopListening: () => dispatchProps.stopListening()
-    }), {
-        withRef: true
-    }
+    // passed down to ShellContainer
+    onChangeText: (input: string) => ({ type: 'Update_Input', input, source: "text" } as ChatActions),
+    stopListening: () => ({ type: 'Listening_Stopping' }),
+    startListening: () => ({ type: 'Listening_Starting' }),
+    // only used to create helper functions below
+    sendMessage,
+    sendFiles,
+    sendScreenshot
+}, (stateProps: any, dispatchProps: any, ownProps: any): Props => ({
+    // from stateProps
+    inputText: stateProps.inputText,
+    showUploadButton: stateProps.showUploadButton,
+    disableInput: stateProps.disableInput,
+    strings: stateProps.strings,
+    listeningState: stateProps.listeningState,
+    // from dispatchProps
+    onChangeText: dispatchProps.onChangeText,
+    // helper functions
+    sendMessage: (text: string) => dispatchProps.sendMessage(text, stateProps.user, stateProps.locale),
+    sendFiles: (files: FileList) => dispatchProps.sendFiles(files, stateProps.user, stateProps.locale),
+    sendScreenshot: (screen: string) => dispatchProps.sendScreenshot(screen, stateProps.user, stateProps.locale),
+    startListening: () => dispatchProps.startListening(),
+    stopListening: () => dispatchProps.stopListening()
+}), {
+    withRef: true
+}
 )(ShellContainer);

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -14,7 +14,7 @@ interface Props {
     inputText: string,
     strings: Strings,
     listeningState: ListeningState,
-    showUploadButton: boolean
+    showUploadButton: boolean,
     disableInput: boolean
 
     onChangeText: (inputText: string) => void
@@ -163,7 +163,7 @@ class ShellContainer extends React.Component<Props> implements ShellFunctions {
                     />
                 }
                 {
-                    this.props.showUploadButton && window.location.hash === '#feedbot-feature-screenshot' && !isSafari() &&
+                    this.props.showUploadButton &&
                     <button className="wc-upload-screenshot" onClick={() => { this.takeScreenshot() }}><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="camera" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="#8a8a8a" d="M512 144v288c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V144c0-26.5 21.5-48 48-48h88l12.3-32.9c7-18.7 24.9-31.1 44.9-31.1h125.5c20 0 37.9 12.4 44.9 31.1L376 96h88c26.5 0 48 21.5 48 48zM376 288c0-66.2-53.8-120-120-120s-120 53.8-120 120 53.8 120 120 120 120-53.8 120-120zm-32 0c0 48.5-39.5 88-88 88s-88-39.5-88-88 39.5-88 88-88 88 39.5 88 88z"></path></svg></button>
                 }
                 <div className="wc-textbox">


### PR DESCRIPTION
- added hiding screenshot upload in safari as this functionality does not work In safari
- added a new prop enableScreenshotUpload to enable screenshot, instead of using the #feedbot-feature-screenshot postfix 