### PR TITLE
fix: 🐛 screenshot button hidden on full-size wc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -507,31 +507,6 @@ const ExpandableKnobTheme = (theme: Theme) => `
     height: 565px;
   }
 
-  .wc-upload-screenshot {
-    display: none !important;
-  }
-
-  ${theme.enableScreenshotUpload && !isSafari() ? `
-    .wc-upload-screenshot {
-      display: inline-block !important;
-      position: absolute !important;
-      left: 46px !important;
-      height: 40px !important;
-      background-color: transparent !important;
-      border: none !important;
-      color: #8a8a8a;
-      padding: 0;
-    }
-    .wc-upload-screenshot svg {
-      margin: 9px 6px !important;
-      width: 32px;
-      height: 22px;
-    }
-    .wc-console.has-upload-button .wc-textbox {
-      left: 96px !important;
-    }
-  ` : ''}
-
   .feedbot-wrapper.collapsed .feedbot-signature {
     display: none;
   }
@@ -1084,6 +1059,31 @@ const BaseTheme = (theme: Theme) => `
     .feedbot-signature {
       display: none;
     }
+
+    .wc-upload-screenshot {
+      display: none !important;
+    }
+  
+    ${theme.enableScreenshotUpload && !isSafari() ? `
+      .wc-upload-screenshot {
+        display: inline-block !important;
+        position: absolute !important;
+        left: 46px !important;
+        height: 40px !important;
+        background-color: transparent !important;
+        border: none !important;
+        color: #8a8a8a;
+        padding: 0;
+      }
+      .wc-upload-screenshot svg {
+        margin: 9px 6px !important;
+        width: 32px;
+        height: 22px;
+      }
+      .wc-console.has-upload-button .wc-textbox {
+        left: 96px !important;
+      }
+    ` : ''}
 
     ${theme.customCss || ""}
   `;


### PR DESCRIPTION
Fixed the hiding of the screenshot button. It was caused by the CSS rule which should've to hide the button, was not affecting the full-size webchat window.
