### PR TITLE
fix: 🐛 wrapping of carousel titles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1054,6 +1054,9 @@ const BaseTheme = (theme: Theme) => `
 
     .wc-carousel .wc-hscroll > ul > li > .wc-card > div > .ac-container > .ac-container .ac-textBlock{
       padding: 0 20px;
+      white-space: unset !important;
+      text-overflow: unset !important;
+      overflow: unset !important;
     }
 
     .wc-carousel .wc-hscroll > ul > li > .wc-card > div .ac-actionSet{


### PR DESCRIPTION
- Changed carousel title styling to wrap to next line.