### PR TITLE
fix: 🐛 failed upload message with direct upload

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -247,6 +247,7 @@ export class Chat extends React.Component<ChatProps, {}> {
                 console.log('User data', newActivity.channelData.userData)
                 return botConnection.postActivityOriginal(newActivity);
             } else if (activity.type === "message" && activity.isDirectUpload) {
+                activity.id = "directupload"
                 console.log("activity", activity)
                 return new Observable()
             } else {


### PR DESCRIPTION
### Story
- when uploading file through direct upload, webchat is showing notice that the message wasn't sent successfully
- was caused by direct upload activity object didn't include ```id```
### Fix
- Added fixed id for direct uploads