### PR TITLE
fix: FBOT-682 carousel styling in fullsize template

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,11 +331,6 @@ const FullScreenTheme = (theme: Theme) => `
     }
   }
 
-  .wc-adaptive-card {
-    border-radius: 8px;
-    padding: 2px 6px;
-  }
-
   .feedbot-wrapper {
     background-color: transparent;
     width: 95%;
@@ -967,7 +962,7 @@ const BaseTheme = (theme: Theme) => `
     .feedbot-wrapper .wc-app .wc-card {
         background-color: transparent;
         border-width: 0px;
-        border-radius: 5px;
+        border-radius: 8px;
     }
 
     .feedbot-wrapper .wc-app .wc-carousel .wc-card {
@@ -1119,6 +1114,15 @@ const BaseTheme = (theme: Theme) => `
       white-space: unset !important;
       text-overflow: unset !important;
       overflow: unset !important;
+    }
+
+    .wc-carousel .wc-hscroll > ul > li > .wc-card > div > .ac-container > .ac-container .ac-textBlock:last-child{
+      padding-bottom: 8px;
+    }
+
+    .wc-carousel .wc-hscroll > ul > li > .wc-card {
+      height: 100%;
+
     }
 
     .wc-carousel .wc-hscroll > ul > li > .wc-card > div .ac-actionSet{


### PR DESCRIPTION
### Story 🐛: Carousel padding in the webchat template does not look good
### Fix 🔧: Fixed with few tweaks and added 100% height of carousel cards by default
- Screenshot after the fix
![image](https://user-images.githubusercontent.com/41472305/134819345-08dd64dc-640d-4aa3-87d9-273c5a7d6282.png)
