### PR TITLE
fix: moved setting screenshot only if theme is defined

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,11 +200,11 @@ export const App = async (props: AppProps, container?: HTMLElement) => {
     : false;
   props.resize = props.hasOwnProperty("resize") ? props.resize : "detect";
   props.locale = props.hasOwnProperty("locale") ? props.locale : "cs-cz";
-  props.theme.enableScreenshotUpload = !!props.enableScreenshotUpload
 
   // FEEDYOU configurable theming
   if (props.theme || !container) {
     const theme = { mainColor: "#D83838", ...props.theme };
+    props.theme.enableScreenshotUpload = !!props.enableScreenshotUpload
     const themeStyle = document.createElement("style");
     themeStyle.type = "text/css";
     themeStyle.appendChild(


### PR DESCRIPTION
- undefined theme broke the chatbot
- now setting screenshot prop to theme only if it exists
- Error message:
![image](https://user-images.githubusercontent.com/41472305/136171568-342863da-176b-4611-89f8-e9f65170b964.png)

