### PR TITLE
fix FBOT-835 Fix IE ... 4realz now!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedyou-ai/feedbot-webchat",
-  "version": "0.14.1-9",
+  "version": "0.14.1-10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "adaptivecards": "^1.1.0",
     "bluebird": "^3.5.1",
     "botframework-directlinejs": "0.9.15",
-    "core-js": "2.4.1",
+    "core-js": "^2.4.1",
     "device-detector-js": "^3.0.0",
     "html2canvas": "^1.0.0-rc.7",
     "isomorphic-fetch": "^3.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
+import "core-js/es6"
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-import { Chat, ChatProps } from "./Chat";
+import { ChatProps } from "./Chat";
 import {
   render,
   renderExpandableTemplate,
@@ -8,7 +8,6 @@ import {
 } from "./AppService";
 import { DirectLine } from "botframework-directlinejs";
 import * as konsole from "./Konsole";
-import * as rgb2hex from "rgb2hex"
 import { getFeedyouParam, setFeedyouParam } from "./FeedyouParams"
 
 export type Theme = {
@@ -208,7 +207,8 @@ export const App = async (props: AppProps, container?: HTMLElement) => {
   }
 
   props.user.id = props.user.id ? String(props.user.id) : MakeId()
-  localStorage.feedbotUserId = props.user.id
+  // localStorage is undefined in IE for file:// testing: https://stackoverflow.com/a/3392301/10467064
+  if(localStorage) localStorage.feedbotUserId = props.user.id
 
   // FEEDYOU props defaults
   props.showUploadButton = props.hasOwnProperty("showUploadButton")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const coreConfig = {
             },
             {
                 test: /\.js$/,
-                include: /(node_modules\/engine.io-client|node_modules\/socket.io-client|node_modules\/smartsupp-websocket|node_modules\/device-detector-js)/,
+                include: /(node_modules\/engine.io-client|node_modules\/socket.io-client|node_modules\/smartsupp-websocket|device-detector-js)/,
                 loader: 'babel-loader',
                 options: {
                     presets: ["es2015"]


### PR DESCRIPTION
TIL: 

- Ty moje původní úpravy ve skutečnosti dělaly něco úplně jinýho, co jsem myslel, a pořádně nerozumím tomu, co
- babel-loader ve skutečnosti netranspiluje (neumí) z es6 na es5: https://stackoverflow.com/a/32148277/10467064
- Object.assign je až z es6

Zkoušel jsem to transpilovat přímo v bundlu, ale furt mi to na něčem padalo. Samotnej Babel [v dokumentaci doporučuje](https://babeljs.io/docs/en/babel-polyfill#__docusaurus) prostě dotáhnout core-js polyfil, tak jsem to nakonec vyřešil tak