### PR TITLE
fix: FBOT-2442 remove width constraints

### DIFF
--- a/src/scss/botchat-fullwindow.scss
+++ b/src/scss/botchat-fullwindow.scss
@@ -1,12 +1,6 @@
 @import "includes/settings";
 @import "includes/card-size";
 
-@media (max-width: 450px) {
-
-  @include card-size($card_narrow);
-
-}
-
 @media (min-width: 768px) {
 
   @include card-size($card_wide);

--- a/src/themes/BaseTheme.tsx
+++ b/src/themes/BaseTheme.tsx
@@ -225,7 +225,6 @@ export const BaseTheme = (theme: Theme) => `
     @media (max-width: 450px) {
       .feedbot-wrapper .wc-card {
         border: 1px solid #d2dde5;
-        width: 198px;
       }
       .feedbot-wrapper .wc-list.tiles .wc-card {
         border: none;


### PR DESCRIPTION
Removed width constraints for cards to keep the content centered and full width